### PR TITLE
Block the first contributions repository

### DIFF
--- a/server.js
+++ b/server.js
@@ -213,22 +213,24 @@ const ExtractContributionsForUser = async (_user, _dateNow, _nextDay) => {
             url: node.repository.url,
             commits: [...commits, commitObj],
           };
-          let repositoryExists = commitsContributions.some(
-            x => x.repositoryName == node.repository.name
-          );
-          if (repositoryExists) {
-            let objToUpdate = commitsContributions.find(
-              element => element.repositoryName == node.repository.name
+          if (newResult.repositoryName !== "first-contributions") {
+            let repositoryExists = commitsContributions.some(
+              x => x.repositoryName == node.repository.name
             );
-            let commitExists = objToUpdate.commits.some(
-              x => x.occurredAt == node.occurredAt
-            );
-            objToUpdate.starsCount = node.repository.stargazerCount;
-            if (!commitExists) {
-              objToUpdate.commits = [...objToUpdate.commits, commitObj];
+            if (repositoryExists) {
+              let objToUpdate = commitsContributions.find(
+                element => element.repositoryName == node.repository.name
+              );
+              let commitExists = objToUpdate.commits.some(
+                x => x.occurredAt == node.occurredAt
+              );
+              objToUpdate.starsCount = node.repository.stargazerCount;
+              if (!commitExists) {
+                objToUpdate.commits = [...objToUpdate.commits, commitObj];
+              }
+            } else {
+              commitsContributions.push(newResult);
             }
-          } else {
-            commitsContributions.push(newResult);
           }
         }
       }


### PR DESCRIPTION
Blocked the first contribution repository from getting counted because its a testing repo for the people to learn how to create their first contributions and the repo have a lot of stars so it will not be accurate to count it into the scores or add it to the database